### PR TITLE
Add missing ARUP specs

### DIFF
--- a/docs/development/network.md
+++ b/docs/development/network.md
@@ -494,8 +494,11 @@ The first argument indicates the information being sent about every area:
 
 - `0`: player counts
 - `1`: area statuses
+  -  Recognized statuses: `IDLE`, `LOOKING-FOR-PLAYERS`, `CASING`, `RECESS`, `RP`, `GAMING`
 - `2`: case managers (CMs)
+  - This should be set to `FREE` if there are no case managers in the area. 
 - `3`: locked states (string, not boolean)
+  - Recognized lock states: `FREE`, `SPECTATABLE`, `LOCKED` 
 
 This packet has as many pieces (plus one) as there are areas on the server. It describes, in order, every area's given property.
 


### PR DESCRIPTION
Currently, there are several possible states that are required for the status, CM, and lock ARUP packets. These are completely undocumented. This PR adds these to the ARUP documentation.