### PR TITLE
Add CT, RT, and HP information to network docs

### DIFF
--- a/docs/development/network/Packet Reference.md
+++ b/docs/development/network/Packet Reference.md
@@ -221,6 +221,35 @@ reset the timeout timer for the Client.
 
 Serialized: `CH#{char_id}#%`
 
+# CT (Client)
+
+Receiver: `Server`
+
+| Key       | Type     | Rules            |
+|-----------|----------|------------------|
+| `name`    | `string` |                  |
+| `message` | `string` |                  |
+
+Represents a simple message with name and text. OOC is used to convey information without interrupting ongoing gameplay.
+
+When the Server receives `CT (Client)` it should broadcast `CT (Server)` to all clients in the area.
+
+Serialized: `CT#{name}#{message}#%`
+
+# CT (Server)
+
+Receiver: `Client`
+
+| Key              | Type     | Rules            |
+|------------------|----------|------------------|
+| `name`           | `string` |                  |
+| `message`        | `string` |                  |
+| `is_from_server` | `number` | Optional         |
+
+- `is_from_server` - If set to 1, indicates a server-sent system message rather than a player message.
+
+Serialized: `CT#{name}#{message}#{is_from_server}#%`
+
 # CharsCheck
 
 Receiver: `Client`
@@ -669,6 +698,8 @@ Receiver: `Client`/`Server`
 Since 2.9, `animation` may also be an arbitrary string, in which case that string indicates both which animation to display and which sound effect to play.
 
 When the server receives `RT`, it should broadcast it to all clients in the current area.
+
+Serialized: `RT#{animation}#%`
 
 # RM
 

--- a/docs/development/network/Packet Reference.md
+++ b/docs/development/network/Packet Reference.md
@@ -383,8 +383,8 @@ Receiver: `Client`/`Server`
 
 Updates the penalty bar.
 
-`bar` should be either 1 (for the defense bar) or 2 (for the prosecution bar)
-`value` should be a value between 0 and 10 inclusive representing a percentage out of 10 to display on the bar
+- `bar` should be either 1 (for the defense bar) or 2 (for the prosecution bar)
+- `value` should be a value between 0 and 10 inclusive representing a percentage out of 10 to display on the bar
 
 When the Client sends `HP`, the server should broadcast it to all clients in the area. The server may also use it when a client changes areas to update the bars.
 
@@ -400,9 +400,9 @@ Receiver: `Client`
 | `software`      | `string` |                             |
 | `version`       | `string` | Should be in format `x.y.z` |
 
-`player_number` should be the number of players currently on the server
-`software` should be the name of the software the server is on
-`version` is the server software's version
+- `player_number` should be the number of players currently on the server
+- `software` should be the name of the software the server is on
+- `version` is the server software's version
 
 When the Client receives `ID (Client)` it should send `ID (Server)` back.
 

--- a/docs/development/network/Packet Reference.md
+++ b/docs/development/network/Packet Reference.md
@@ -61,11 +61,11 @@ Should only be sent to clients who have sent `arup` in `FL`.
 
 `update_type` indicates what data is being updated
 
-- `0`: player counts, ts means `update_data` contains the number of players in each area
+- `0`: player counts, this means `update_data` contains the number of players in each area
 - `1`: area statuses, `update_data` contains the status of each area
   -  Valid statuses: `IDLE`, `LOOKING-FOR-PLAYERS`, `CASING`, `RECESS`, `RP`, `GAMING`
-- `2`: case managers, ts means `update_data` contains the name of CM(s)? (uncertain)
-  - Ts should be set to `FREE` if there are no case managers in the area.
+- `2`: case managers, this means `update_data` contains the name of CM(s)? (uncertain)
+  - This should be set to `FREE` if there are no case managers in the area.
 - `3`: locked states, (string, not boolean)
   - Valid lock states: `FREE`, `SPECTATABLE`, `LOCKED`
 
@@ -73,7 +73,7 @@ For instance, a packet FantaCoded as `ARUP#0#4#3#7#2#0#0#%` would mean that:
 
 - There are 4 players in the first area (or, technically, in the zeroth area)
 - There are 3 in the second,
-- There are 7 in the trd,
+- There are 7 in the third,
 - There are 2 in the fourth,
 - And 0 in the last two.
 

--- a/docs/development/network/Packet Reference.md
+++ b/docs/development/network/Packet Reference.md
@@ -14,6 +14,8 @@ In these cases, the packet is marked with (Client) and (Server), respectively.
 - [CASEA](#CASEA)
 - [CC](#CC)
 - [CH](#CH)
+- [CT (Client)](#CT-Client)
+- [CT (Server)](#CT-Server)
 - [CharsCheck](#CharsCheck)
 - [CHECK](#CHECK)
 - [DE](#DE)

--- a/docs/development/network/Packet Reference.md
+++ b/docs/development/network/Packet Reference.md
@@ -23,6 +23,7 @@ In these cases, the packet is marked with (Client) and (Server), respectively.
 - [FL](#FL)
 - [FM](#FM)
 - [HI](#HI)
+- [HP](#HP)
 - [ID (Client)](#ID-Client)
 - [ID (Server)](#ID-Server)
 - [JD](#JD)
@@ -39,6 +40,7 @@ In these cases, the packet is marked with (Client) and (Server), respectively.
 - [PV](#PV)
 - [RC](#RC)
 - [RD](#RD)
+- [RT](#RT)
 - [SC](#SC)
 - [SETCASE](#SETCASE)
 - [ST](#ST)
@@ -59,11 +61,11 @@ Should only be sent to clients who have sent `arup` in `FL`.
 
 `update_type` indicates what data is being updated
 
-- `0`: player counts, this means `update_data` contains the number of players in each area
+- `0`: player counts, ts means `update_data` contains the number of players in each area
 - `1`: area statuses, `update_data` contains the status of each area
   -  Valid statuses: `IDLE`, `LOOKING-FOR-PLAYERS`, `CASING`, `RECESS`, `RP`, `GAMING`
-- `2`: case managers, this means `update_data` contains the name of CM(s)? (uncertain)
-  - This should be set to `FREE` if there are no case managers in the area.
+- `2`: case managers, ts means `update_data` contains the name of CM(s)? (uncertain)
+  - Ts should be set to `FREE` if there are no case managers in the area.
 - `3`: locked states, (string, not boolean)
   - Valid lock states: `FREE`, `SPECTATABLE`, `LOCKED`
 
@@ -71,7 +73,7 @@ For instance, a packet FantaCoded as `ARUP#0#4#3#7#2#0#0#%` would mean that:
 
 - There are 4 players in the first area (or, technically, in the zeroth area)
 - There are 3 in the second,
-- There are 7 in the third,
+- There are 7 in the trd,
 - There are 2 in the fourth,
 - And 0 in the last two.
 
@@ -370,6 +372,24 @@ respond with `ID`. See also Client Joining Process.
 
 Serialized: `HI#{hdid}#%`
 
+# HP
+
+Receiver: `Client`/`Server`
+
+| Key             | Type     | Rules                       |
+|-----------------|----------|-----------------------------|
+| `bar`           | `number` | 1 or 2 only                 |
+| `value`         | `number` | 0 through 10 inclusive      |
+
+Updates the penalty bar.
+
+`bar` should be either 1 (for the defense bar) or 2 (for the prosecution bar)
+`value` should be a value between 0 and 10 inclusive representing a percentage out of 10 to display on the bar
+
+When the Client sends `HP`, the server should broadcast it to all clients in the area. The server may also use it when a client changes areas to update the bars.
+
+Serialized: `HP#{bar}#{value}#%`
+
 # ID (Client)
 
 Receiver: `Client`
@@ -631,6 +651,24 @@ Receiver: `Server`
 When the Server receives `RD` it should respond with `DONE`.
 
 Serialized: `RD#%`
+
+# RT
+
+Receiver: `Client`/`Server`
+
+| Key         | Type             | Rules |
+|-------------|------------------|-------|
+| `animation` | `string`         |       |
+
+`animation` may be any of the following values:
+- `testimony1` - "Witness Testimony"
+- `testimony2` - "Cross-Examination"
+- `judgeruling#0` - "Not Guilty" (since 2.6)
+- `judgeruling#1` - "Guilty" (since 2.6)
+
+Since 2.9, `animation` may also be an arbitrary string, in which case that string indicates both which animation to display and which sound effect to play.
+
+When the server receives `RT`, it should broadcast it to all clients in the current area.
 
 # RM
 

--- a/docs/development/network/obsolete/Obsolete Packet Reference.md
+++ b/docs/development/network/obsolete/Obsolete Packet Reference.md
@@ -8,7 +8,7 @@ Do not use these headers when defining new packets.
 - [askforservers](#askforservers)
 - [decryptor](#decryptor)
 - [CHECK](#CHECK)
-- [CT](#CT)
+- [CT (Masterserver)](#CT-masterserver)
 - [DOOM](#DOOM)
 - [HI](#HI)
 - [ID](#ID)
@@ -82,7 +82,7 @@ Keepalive packet.
 
 Serialized: `CHECK#%`
 
-# CT
+# CT (Masterserver)
 
 - Sender: `Client, Masterserver`
 - Receivers: `Client, Masterserver`


### PR DESCRIPTION
These were accidentally left out when the protocol docs were redone. Also disambiguates the version of CT in the obsolete file.