### PR TITLE
network: reintroduce deprecated desk modifier `chat`

### DIFF
--- a/docs/Development/network/MS Packet Reference.md
+++ b/docs/Development/network/MS Packet Reference.md
@@ -50,6 +50,7 @@ Reference of fields:
 - `desk_modifier`: Whether or not to override desk appearance.
   - `0`: desk is hidden
   - `1`: desk is shown
+    - `chat`: deprecated alias for `1`. Clients should rewrite it to 1, or reject it. Servers should rewrite it to 1, or reject it.
   - `2`: desk is hidden during preanim, shown when it ends
   - `3`: desk is shown during preanim, hidden when it ends
   - `4`: desk is hidden during preanim, character is centered and pairing is ignored, when it ends desk is shown and pairing is restored


### PR DESCRIPTION
the description of `chat` was removed in 3c2c2b9, probably because it was incorrect. the actual behavior varies.

servers handle it as follows:
- [Akashi](https://github.com/AttorneyOnline/akashi/blob/16cee9e27c7db7fa7b4dd4c1288ebfbf05e28a2c/src/packet/packet_ms.cpp#L128) rewrites it to 1 server-side
- [KFO-server](https://github.com/Crystalwarrior/KFO-Server/blob/7b17981d8b88faacdb9c778679fa4a60c881c868/server/network/aoprotocol.py#L875-L876) rewrites it to 1 server-side
- [Nyathena](https://github.com/SyntaxNyah/Nyathena/blob/86b15e69666f0635e7be4aee67a3f14335f85c66/internal/athena/netprotocol.go#L813-L816) rewrites it to 1 server-side (skidded from Akashi)
- [serverD](https://github.com/AttorneyOnline/serverD/blob/2c037e28f2400cb4e781059c053199151d074038/server_shared.pb#L560) passes it through verbatim

clients handle it as follows:
- WebAO[[1]](https://github.com/AttorneyOnline/webAO/blob/76941bf99c5e7ba4deda080013ac8173e02a1c2a/webAO/packets/handlers/handleMS.ts#L61)[[2]](https://github.com/AttorneyOnline/webAO/blob/76941bf99c5e7ba4deda080013ac8173e02a1c2a/webAO/viewport/utils/handleICSpeaking.ts#L245-L249) rewrites it to 1
- [AO2](https://github.com/AttorneyOnline/AO2-Client/blob/master/src/courtroom.cpp#L4095) rewrites it to 0
- [AsyncAO](https://github.com/SyntaxNyah/AsyncAO/blob/main/internal/protocol/ms.go#L169-L171) rewrites it to 0 (skidded from AO2)

for consistent behavior across different servers and clients, servers and clients should rewrite it to 1 or reject it.