### PR TITLE
network: remove comment claiming that clients send `FL`

### DIFF
--- a/docs/Development/network/Packet Reference.md
+++ b/docs/Development/network/Packet Reference.md
@@ -64,7 +64,7 @@ Receiver: `Client`
 | `update_data` | `array[int\|string]` |       |
 
 Updates a status for all areas.
-Should only be sent to clients who have sent `arup` in `FL`.
+Sent by servers who have `arup` in `FL`.
 
 `update_type` indicates what data is being updated
 


### PR DESCRIPTION
as far as i can tell, clients never send `FL`, and `arup` is actually a feature in `FL` sent by the server.